### PR TITLE
Hide API keys by default, add 'show' icon to display

### DIFF
--- a/frontend/js/apiKeys/apikey-styles.less
+++ b/frontend/js/apiKeys/apikey-styles.less
@@ -1,3 +1,5 @@
+@import (reference) '~nav-frontend-core/less/_variabler';
+
 .errorMessage,
 .apikeyCard,
 .infoPanel {
@@ -59,4 +61,33 @@
 .apiButtons {
   display: flex;
   flex-direction: row-reverse;
+}
+
+.key {
+  font-family: 'Courier New', Courier, monospace;
+  font-size: 14px;
+  border-radius: 5px;
+  padding: 0 10px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.keyWrapper {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  display: flex;
+  flex-direction: row;
+  align-items: baseline;
+}
+
+.eye {
+  background-color: @navGra20;
+  border-radius: 5px;
+  padding: 0 5px 2px 5px;
+}
+
+.eye:hover,
+.eye:focus {
+  background-color: @navGra40;
 }

--- a/frontend/js/apiKeys/teamCard.tsx
+++ b/frontend/js/apiKeys/teamCard.tsx
@@ -7,7 +7,7 @@ import { Fareknapp, Knapp } from 'nav-frontend-knapper'
 import { CopyToClipboard } from 'react-copy-to-clipboard'
 import moment from 'moment'
 import './apikey-styles.less'
-import { Copy, CopyFilled, RefreshFilled } from '@navikt/ds-icons'
+import { Copy, CopyFilled, EyeFilled, EyeScreenedFilled, RefreshFilled } from '@navikt/ds-icons'
 
 const azureAdGroupUrl =
   'https://portal.azure.com/#blade/Microsoft_AAD_IAM/GroupDetailsMenuBlade/Overview/groupId/'
@@ -38,6 +38,7 @@ const findNewestKey = (apiKeys) => {
 
 function TeamCard(props: Props) {
   const [copied, setCopied] = useState(false)
+  const [hidden, setHidden] = useState(true)
   const { apiKeys, handleKeyRotation } = props
   const { team, key, expires, groupId, created } = findNewestKey(apiKeys)
 
@@ -51,10 +52,17 @@ function TeamCard(props: Props) {
   return (
     <Panel border className="apikeyCard">
       <Undertittel>{team}</Undertittel>
-      <Element style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>
+      <div className="keyWrapper">
         <KeyIcon />
-        {key}
-      </Element>
+        <Element className="key">{hidden ? '*'.repeat(key.length) : key}</Element>
+        <div className="eye">
+          {hidden ? (
+            <EyeFilled onClick={() => setHidden(!hidden)} />
+          ) : (
+            <EyeScreenedFilled onClick={() => setHidden(!hidden)} />
+          )}
+        </div>
+      </div>
       <KeyStatus expiresTimestamp={expires} />
       <Normaltekst>{`Created ${formatTimestamp(created)}`}</Normaltekst>
       <Element className="aad">{`Azure AD team id`}</Element>


### PR DESCRIPTION
As @x10an14 mentioned in #14, we should hide the API key by default. I've implemented a simple hide/show button to implement this.

![image](https://user-images.githubusercontent.com/2280539/124483374-8f1aa900-ddaa-11eb-96f3-3795b7e3c9f5.png)

![image](https://user-images.githubusercontent.com/2280539/124483405-980b7a80-ddaa-11eb-9f27-82318534cba8.png)
