### PR TITLE
Add /apikeys to the ingress, preventing an unexpected 404 on reload

### DIFF
--- a/.nais/ci-config.json
+++ b/.nais/ci-config.json
@@ -5,6 +5,7 @@
     "https://deploy.ci.nav.no/oauth2",
     "https://deploy.ci.nav.no/logout",
     "https://deploy.ci.nav.no/me",
+    "https://deploy.ci.nav.no/apikeys",
     "https://deploy.ci.nav.no/downstream"
   ],
   "reply-url": "https://deploy.ci.nav.no/oauth2/callback",

--- a/.nais/dev-config.json
+++ b/.nais/dev-config.json
@@ -5,6 +5,7 @@
     "https://deploy.dev-gcp.nais.io/oauth2",
     "https://deploy.dev-gcp.nais.io/logout",
     "https://deploy.dev-gcp.nais.io/me",
+    "https://deploy.dev-gcp.nais.io/apikeys",
     "https://deploy.dev-gcp.nais.io/downstream"
   ],
   "reply-url": "https://deploy.dev-gcp.nais.io/oauth2/callback",

--- a/.nais/prod-config.json
+++ b/.nais/prod-config.json
@@ -5,6 +5,7 @@
     "https://deploy.nais.io/oauth2",
     "https://deploy.nais.io/logout",
     "https://deploy.nais.io/me",
+    "https://deploy.nais.io/apikeys",
     "https://deploy.nais.io/downstream"
   ],
   "reply-url": "https://deploy.nais.io/oauth2/callback",


### PR DESCRIPTION
I'm not completely sure why we're not sending all traffic to the node backend, but I expect that this allows visiting the `/apikeys` path directly.
Example of confusion: [Slack](https://nav-it.slack.com/archives/C5KUST8N6/p1626856625237500?thread_ts=1626856432.236800&cid=C5KUST8N6)